### PR TITLE
Check for io_counters feature

### DIFF
--- a/crossbar/common/monitor.py
+++ b/crossbar/common/monitor.py
@@ -154,11 +154,12 @@ class ProcessMonitor(Monitor):
 
         self._has_io_counters = False
         if not sys.platform.startswith('darwin'):
-            try:
-                self._p.io_counters()
-                self._has_io_counters = True
-            except psutil.AccessDenied:
-                pass
+            if hasattr(self._p, 'io_counters'):
+                try:
+                    self._p.io_counters()
+                    self._has_io_counters = True
+                except psutil.AccessDenied:
+                    pass
 
     @inlineCallbacks
     def poll(self, verbose=False):


### PR DESCRIPTION
This resolves [#1618](https://github.com/crossbario/crossbar/issues/1618) by checking for the attribute 'io_counters' before trying to access it on Linux systems.
